### PR TITLE
Handle missing video asset in HUD

### DIFF
--- a/client/src/components/game/HUD.tsx
+++ b/client/src/components/game/HUD.tsx
@@ -88,8 +88,13 @@ export function HUD() {
   const cellsExplored = visitedCells.size;
 
   useEffect(() => {
-    if (isGameOver && videoRef.current) {
-      videoRef.current.play().catch(() => {});
+    if (isGameOver) {
+      if (!VIDEO_ASSETS.BEPPO_GAME_OVER.url) {
+        // Skip video if not available
+        setVideoEnded(true);
+      } else if (videoRef.current) {
+        videoRef.current.play().catch(() => {});
+      }
     }
   }, [isGameOver]);
 
@@ -231,7 +236,7 @@ export function HUD() {
             className="absolute inset-0 bg-black flex flex-col items-center justify-center z-50"
           >
             {/* Video plays first */}
-            {!videoEnded && (
+            {!videoEnded && VIDEO_ASSETS.BEPPO_GAME_OVER.url && (
               <video
                 ref={videoRef}
                 src={VIDEO_ASSETS.BEPPO_GAME_OVER.url}
@@ -245,7 +250,7 @@ export function HUD() {
               />
             )}
 
-            {/* Text appears after video */}
+            {/* Text appears after video or immediately if no video */}
             <motion.div
               initial={{ opacity: 0, scale: 0 }}
               animate={{


### PR DESCRIPTION
Gracefully handles the missing game over video asset by:

- Checking if VIDEO_ASSETS.BEPPO_GAME_OVER.url exists before attempting playback
- Immediately showing game over text if video URL is missing
- Only rendering video element when URL is available

This prevents errors when the video asset is not available (currently set to empty string in textures.ts).

Closes #99

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved game-over screen reliability by handling scenarios where video assets are unavailable, ensuring proper text display regardless of playback state.

* **Tests**
  * Enhanced test coverage for game-over functionality to validate behavior across different video asset availability states.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->